### PR TITLE
Support for additional client arguments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ How to set up server with Zabbix agent:
   * Clone this repo.
   * Edit `/etc/zabbix/zabbix_agentd.conf`. Add the following line:
 ```bash
-	UserParameter=ch_params[*],sh /PATH/TO/zbx_clickhouse_monitor.sh "$1" "HOST_WHERE_CH_IS_RUNNING"
+	UserParameter=ch_params[*],sh /PATH/TO/zbx_clickhouse_monitor.sh "$1" "HOST_WHERE_CH_IS_RUNNING" "ADDITIONAL CLICKHOUSE-CLIENT PARAMS"
 ```
   where:
   * `/PATH/TO/zbx_clickhouse_monitor.sh` depends on where you've cloned this repo.
   * `HOST_WHERE_CH_IS_RUNNING` is optional parameter, in case none specified `localhost` would be used
+  * `ADDITIONAL CLICKHOUSE-CLIENT PARAMS` is optional string appended to any clickhouse-client call. Useful if authorization or ssl required
 
 And finally
   * Import `zbx_clickhouse_template.xml` in zabbix (**zabbix -> Configuration -> Templates -> Import**).

--- a/zbx_clickhouse_monitor.sh
+++ b/zbx_clickhouse_monitor.sh
@@ -16,7 +16,7 @@ CH_HOST="${2:-localhost}"
 ##
 function usage()
 {
-	echo "Usage: $(basename "$0") Command [ClickHouse Host to Connect]"
+	echo "Usage: $(basename "$0") Command [ClickHouse Host to Connect] [Additional ClickHouse-Client flags]"
 }
 
 # Command to execute
@@ -26,6 +26,9 @@ if [ -z "$ITEM" ]; then
 	usage
 	exit 1
 fi
+
+# Collect for additional parameters if available. Always get last argument if args count > 2.
+if [ $# -gt 2 ] ; then  ADD_FLAGS="${@: -1}" ; else ADD_FLAGS="" ; fi
 
 # Ensure xmllint is available
 xmllint="$(which xmllint)"
@@ -57,7 +60,7 @@ function run_ch_query()
 	DATABASE="system"
 
 	SQL="SELECT value FROM ${DATABASE}.${TABLE} WHERE $COLUMN = '$METRIC'"
-	/usr/bin/clickhouse-client -h "$CH_HOST" -d "$DATABASE" -q "$SQL"
+	/usr/bin/clickhouse-client -h "$CH_HOST" -d "$DATABASE" -q "$SQL" $(echo "$ADD_FLAGS")
 }
 
 ##
@@ -94,7 +97,7 @@ function run_ch_process_command()
 {
 	DATABASE="system"
 	SQL="SELECT elapsed FROM processes"
-	/usr/bin/clickhouse-client -h "$CH_HOST" -d "$DATABASE" -q "$SQL"
+	/usr/bin/clickhouse-client -h "$CH_HOST" -d "$DATABASE" -q "$SQL" $(echo "$ADD_FLAGS")
 }
 
 ##


### PR DESCRIPTION
example:
zbx_clickhouse_monitor.sh $1 localhost "-s -u zabbix --password 123"

This arg must be quoted and stay last (might not be 3rd in future).

Currently there is no possibility to specify ssl mode or custom port. I think this approach is quite flexible.