### PR TITLE
Get rid of 'du' and make script POSIX compatible

### DIFF
--- a/zbx_clickhouse_agent.example.conf
+++ b/zbx_clickhouse_agent.example.conf
@@ -1,1 +1,1 @@
-UserParameter=ch_params[*],bash /etc/zabbix/scripts/zbx_clickhouse_monitor.sh "$1" "${CLICKHOUSE_SERVER}" "--user default --connect_timeout 5 --receive_timeout 5"
+UserParameter=ch_params[*],bash /etc/zabbix/scripts/zbx_clickhouse_monitor.sh "$1" "${CLICKHOUSE_SERVER}" --user default --connect_timeout 5 --receive_timeout 5

--- a/zbx_clickhouse_monitor.sh
+++ b/zbx_clickhouse_monitor.sh
@@ -29,7 +29,7 @@ fi
 # Collect additional parameters if available. Get last argument if args count > 2.
 # IMPORTANT Middle agruments are skipped for simplicity
 if [ $# -gt 2 ]; then
-	ADD_FLAGS="${*:2}"
+	ADD_FLAGS="${*:3}"
 else
 	ADD_FLAGS=""
 fi
@@ -63,7 +63,7 @@ function run_ch_query()
 	DATABASE="system"
 
 	SQL="SELECT value FROM ${DATABASE}.${TABLE} WHERE $COLUMN = '$METRIC'"
-	clickhouse-client -h "$CH_HOST" -d "$DATABASE" -q "$SQL" "$ADD_FLAGS"
+	clickhouse-client -h "$CH_HOST" -d "$DATABASE" -q "$SQL" $ADD_FLAGS
 }
 
 ##

--- a/zbx_clickhouse_monitor.sh
+++ b/zbx_clickhouse_monitor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Yandex ClickHouse Zabbix template
 #
@@ -35,7 +35,7 @@ else
 fi
 
 # Ensure xmllint is available
-if ! which xmllint; then
+if ! command -v xmllint &>/dev/null; then
 	echo "Looks like xmllint is not available. Please install it."
 	exit 1
 fi

--- a/zbx_clickhouse_monitor.sh
+++ b/zbx_clickhouse_monitor.sh
@@ -116,7 +116,7 @@ function run_ch_event_command_zeropad()
 
 case "$ITEM" in
 	DiskUsage)
-		clickhouse client -h "$CH_HOST" -q 'SELECT total_space,free_space FROM system.disks;' | awk '{printf($1 - $2)}'
+		clickhouse client -h "$CH_HOST" $ADD_FLAGS -q 'SELECT total_space,free_space FROM system.disks;'| awk '{printf($1 - $2)}'
 		;;
 
 	Revision)

--- a/zbx_clickhouse_monitor.sh
+++ b/zbx_clickhouse_monitor.sh
@@ -6,7 +6,6 @@
 # Copyright (C) Altinity Ltd
 
 
-
 # Default host where ClickHouse is expected to be available
 # You may want to change this for your installation
 CH_HOST="${2:-localhost}"
@@ -20,7 +19,7 @@ function usage()
 }
 
 # Command to execute
-ITEM="$1"
+ITEM=$1
 if [ -z "$ITEM" ]; then
 	echo "Provide command to run"
 	usage
@@ -30,14 +29,13 @@ fi
 # Collect additional parameters if available. Get last argument if args count > 2.
 # IMPORTANT Middle agruments are skipped for simplicity
 if [ $# -gt 2 ]; then
-	ADD_FLAGS="${@: -1}"
+	ADD_FLAGS="${*:2}"
 else
 	ADD_FLAGS=""
 fi
 
 # Ensure xmllint is available
-xmllint="$(which xmllint)"
-if [ "$?" -ne 0 ]; then
+if ! which xmllint; then
 	echo "Looks like xmllint is not available. Please install it."
 	exit 1
 fi
@@ -65,7 +63,7 @@ function run_ch_query()
 	DATABASE="system"
 
 	SQL="SELECT value FROM ${DATABASE}.${TABLE} WHERE $COLUMN = '$METRIC'"
-	clickhouse-client -h "$CH_HOST" -d "$DATABASE" -q "$SQL" $(echo "$ADD_FLAGS")
+	clickhouse-client -h "$CH_HOST" -d "$DATABASE" -q "$SQL" "$ADD_FLAGS"
 }
 
 ##
@@ -102,7 +100,7 @@ function run_ch_process_command()
 {
 	DATABASE="system"
 	SQL="SELECT elapsed FROM processes"
-	clickhouse-client -h "$CH_HOST" -d "$DATABASE" -q "$SQL" $(echo "$ADD_FLAGS")
+	clickhouse-client -h "$CH_HOST" -d "$DATABASE" -q "$SQL" "$ADD_FLAGS"
 }
 
 ##
@@ -111,7 +109,7 @@ function run_ch_process_command()
 function run_ch_event_command_zeropad()
 {
 	# $1 - metric name to fetch
-	res=`run_ch_query 'events' 'event' $1`
+	res=$(run_ch_query 'events' 'event' $1)
 	[ -n "$res" ] || res=0
 	echo "$res"
 }
@@ -122,7 +120,7 @@ case "$ITEM" in
 		;;
 
 	Revision)
-		cat  "$CH_PATH/status" | grep Revision | awk '{print $2}'
+		grep Revision "$CH_PATH/status" | awk '{print $2}'
 		;;
 
 	LongestRunningQuery)

--- a/zbx_clickhouse_monitor.sh
+++ b/zbx_clickhouse_monitor.sh
@@ -27,7 +27,7 @@ if [ -z "$ITEM" ]; then
 	exit 1
 fi
 
-# Collect additional parameters if available. Get last argument if args count > 2. 
+# Collect additional parameters if available. Get last argument if args count > 2.
 # IMPORTANT Middle agruments are skipped for simplicity
 if [ $# -gt 2 ]; then
 	ADD_FLAGS="${@: -1}"
@@ -48,7 +48,7 @@ CH_PATH="$(xmllint --xpath 'string(/yandex/path)' /etc/clickhouse-server/config.
 if [ "$?" -ne 0 ]; then
 	echo "Something went wrong with parsing ClickHouse config. Is xmllint installed? Is ClickHouse config available?"
 	exit 1
-fi 
+fi
 
 ##
 ## Run ClickHouse monitoring query
@@ -118,7 +118,7 @@ function run_ch_event_command_zeropad()
 
 case "$ITEM" in
 	DiskUsage)
-		du -sb "$CH_PATH" | awk '{print $1}'
+		clickhouse client -h "$CH_HOST" -q 'SELECT total_space,free_space FROM system.disks;' | awk '{printf($1 - $2)}'
 		;;
 
 	Revision)
@@ -184,4 +184,3 @@ case "$ITEM" in
 		exit 1
 		;;
 esac
-

--- a/zbx_clickhouse_monitor.sh
+++ b/zbx_clickhouse_monitor.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Yandex ClickHouse Zabbix template
 #
@@ -29,7 +29,7 @@ fi
 # Collect additional parameters if available. Get last argument if args count > 2.
 # IMPORTANT Middle agruments are skipped for simplicity
 if [ $# -gt 2 ]; then
-	ADD_FLAGS="${*:-1}"
+	ADD_FLAGS="${*:3}"
 else
 	ADD_FLAGS=""
 fi
@@ -63,7 +63,7 @@ function run_ch_query()
 	DATABASE="system"
 
 	SQL="SELECT value FROM ${DATABASE}.${TABLE} WHERE $COLUMN = '$METRIC'"
-	clickhouse-client -h "$CH_HOST" -d "$DATABASE" -q "$SQL" "$ADD_FLAGS"
+	clickhouse-client -h "$CH_HOST" -d "$DATABASE" -q "$SQL" $ADD_FLAGS
 }
 
 ##
@@ -100,7 +100,7 @@ function run_ch_process_command()
 {
 	DATABASE="system"
 	SQL="SELECT elapsed FROM processes"
-	clickhouse-client -h "$CH_HOST" -d "$DATABASE" -q "$SQL" "$ADD_FLAGS"
+	clickhouse-client -h "$CH_HOST" -d "$DATABASE" -q "$SQL" $ADD_FLAGS
 }
 
 ##
@@ -116,7 +116,7 @@ function run_ch_event_command_zeropad()
 
 case "$ITEM" in
 	DiskUsage)
-		clickhouse client -h "$CH_HOST" -q 'SELECT total_space,free_space FROM system.disks;' "$ADD_FLAGS"| awk '{printf($1 - $2)}'
+		clickhouse client -h "$CH_HOST" -q 'SELECT total_space,free_space FROM system.disks;' $ADD_FLAGS| awk '{printf($1 - $2)}'
 		;;
 
 	Revision)

--- a/zbx_clickhouse_monitor.sh
+++ b/zbx_clickhouse_monitor.sh
@@ -29,13 +29,13 @@ fi
 # Collect additional parameters if available. Get last argument if args count > 2.
 # IMPORTANT Middle agruments are skipped for simplicity
 if [ $# -gt 2 ]; then
-	ADD_FLAGS="${*:3}"
+	ADD_FLAGS="${*:-1}"
 else
 	ADD_FLAGS=""
 fi
 
 # Ensure xmllint is available
-if ! command -v xmllint &>/dev/null; then
+if ! command -v xmllint >/dev/null 2>&1; then
 	echo "Looks like xmllint is not available. Please install it."
 	exit 1
 fi
@@ -63,7 +63,7 @@ function run_ch_query()
 	DATABASE="system"
 
 	SQL="SELECT value FROM ${DATABASE}.${TABLE} WHERE $COLUMN = '$METRIC'"
-	clickhouse-client -h "$CH_HOST" -d "$DATABASE" -q "$SQL" $ADD_FLAGS
+	clickhouse-client -h "$CH_HOST" -d "$DATABASE" -q "$SQL" "$ADD_FLAGS"
 }
 
 ##
@@ -116,7 +116,7 @@ function run_ch_event_command_zeropad()
 
 case "$ITEM" in
 	DiskUsage)
-		clickhouse client -h "$CH_HOST" $ADD_FLAGS -q 'SELECT total_space,free_space FROM system.disks;'| awk '{printf($1 - $2)}'
+		clickhouse client -h "$CH_HOST" -q 'SELECT total_space,free_space FROM system.disks;' "$ADD_FLAGS"| awk '{printf($1 - $2)}'
 		;;
 
 	Revision)


### PR DESCRIPTION
Using `du` for `DiskUsage` function can cause troubles with permissions. To avoid this, we can use ClickHouse query.
Some script constructions were replaced with a cleaner way.